### PR TITLE
l2 connection - supported aside service token

### DIFF
--- a/client.go
+++ b/client.go
@@ -99,6 +99,7 @@ type L2Connection struct {
 	RedundantUUID       *string
 	RedundancyType      *string
 	Actions             []L2ConnectionAction
+	ServiceToken        *string
 }
 
 //L2ConnectionAdditionalInfo additional info object used in L2 connections

--- a/internal/api/l2_connection.go
+++ b/internal/api/l2_connection.go
@@ -26,6 +26,7 @@ type L2ConnectionResponse struct {
 	RedundantUUID       *string                      `json:"redundantUUID,omitempty"`
 	RedundancyType      *string                      `json:"redundancyType,omitempty"`
 	ActionDetails       []L2ConnectionActionDetail   `json:"actionDetails,omitempty"`
+	VendorToken         *string                      `json:"vendorToken,omitempty"`
 }
 
 //DeleteL2ConnectionResponse l2 connection delete response
@@ -70,6 +71,7 @@ type L2ConnectionRequest struct {
 	SellerRegion               *string                      `json:"sellerRegion,omitempty"`
 	SellerMetroCode            *string                      `json:"sellerMetroCode,omitempty"`
 	AuthorizationKey           *string                      `json:"authorizationKey,omitempty"`
+	PrimaryServiceToken        *string                      `json:"primaryServiceToken,omitempty"`
 }
 
 //CreateL2ConnectionResponse post l2 connection response

--- a/rest_l2_connection.go
+++ b/rest_l2_connection.go
@@ -175,6 +175,7 @@ func mapGETToL2Connection(getResponse api.L2ConnectionResponse) *L2Connection {
 		RedundantUUID:       getResponse.RedundantUUID,
 		RedundancyType:      getResponse.RedundancyType,
 		Actions:             mapL2ConnectionActionsAPIToDomain(getResponse.ActionDetails),
+		ServiceToken:        getResponse.VendorToken,
 	}
 }
 
@@ -198,7 +199,9 @@ func createL2ConnectionRequest(l2connection L2Connection) api.L2ConnectionReques
 		PrimaryZSideVlanCTag: l2connection.ZSideVlanCTag,
 		SellerRegion:         l2connection.SellerRegion,
 		SellerMetroCode:      l2connection.SellerMetroCode,
-		AuthorizationKey:     l2connection.AuthorizationKey}
+		AuthorizationKey:     l2connection.AuthorizationKey,
+		PrimaryServiceToken:  l2connection.ServiceToken,
+	}
 }
 
 func createL2RedundantConnectionRequest(primary L2Connection, secondary L2Connection) api.L2ConnectionRequest {

--- a/test-fixtures/ecx_l2connection_get_resp.json
+++ b/test-fixtures/ecx_l2connection_get_resp.json
@@ -47,6 +47,7 @@
     "self": false,
     "redundantUUID": "a653087c-f128-41d9-967d-c718223a72d6",
     "namedTag": "Private",
+    "vendorToken": "a87166ad0-9e02-42b6-bfc3-b3696d53db12",
     "additionalInfo": [
         {
             "name": "global",


### PR DESCRIPTION
Added support to create ecx/v3 l2 connections using a [Fabric Service Token ](https://docs.equinix.com/en-us/Content/Interconnection/Fabric/service%20tokens/Fabric-Service-Tokens.htm). 

- Request field is `primaryServiceToken`
- Value is returned in the get connection by uuid in `vendorToken`
- Value is exposed in the client as `ServiceToken`
- This attribute is not supported in redundant connections API calls (secondary attributes), not even from the portal. To create a redundant connection, it will be required two connection requests, one for each service token

fix https://github.com/equinix/ecx-go/issues/2