### PR TITLE
added field secondaryServiceToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.0 (March 11, 2022)
+
+FEATURES:
+
+* **L2Connection** redundant connection now can be created with a ServiceToken (one a-side service
+ token for each connection)
+
 ## 2.1.1 (February 28, 2022)
 
 ENHANCEMENTS:
@@ -10,7 +17,8 @@ ENHANCEMENTS:
 FEATURES:
 
 * **L2Connection** can be created with a ServiceToken (in addition to port and device identifier)
- key given by a provider that grants you authorization to enable connectivity from a shared multi-tenant port (a-side)
+ key given by a provider that grants you authorization to enable connectivity from a shared
+ multi-tenant port (a-side)
 
 ## 2.0.3 (March 03, 2021)
 

--- a/internal/api/l2_connection.go
+++ b/internal/api/l2_connection.go
@@ -46,6 +46,7 @@ type L2ConnectionRequest struct {
 	PurchaseOrderNumber        *string                      `json:"purchaseOrderNumber"`
 	PrimaryPortUUID            *string                      `json:"primaryPortUUID,omitempty"`
 	VirtualDeviceUUID          *string                      `json:"virtualDeviceUUID,omitempty"`
+	PrimaryServiceToken        *string                      `json:"primaryServiceToken,omitempty"`
 	InterfaceID                *int                         `json:"interfaceId,omitempty"`
 	PrimaryVlanSTag            *int                         `json:"primaryVlanSTag,omitempty"`
 	PrimaryVlanCTag            *int                         `json:"primaryVlanCTag,omitempty"`
@@ -69,10 +70,10 @@ type L2ConnectionRequest struct {
 	SecondarySellerMetroCode   *string                      `json:"secondarySellerMetroCode,omitempty"`
 	SecondarySellerRegion      *string                      `json:"secondarySellerRegion,omitempty"`
 	SecondaryInterfaceID       *int                         `json:"secondaryInterfaceId,omitempty"`
+	SecondaryServiceToken      *string                      `json:"secondaryServiceToken,omitempty"`
 	SellerRegion               *string                      `json:"sellerRegion,omitempty"`
 	SellerMetroCode            *string                      `json:"sellerMetroCode,omitempty"`
 	AuthorizationKey           *string                      `json:"authorizationKey,omitempty"`
-	PrimaryServiceToken        *string                      `json:"primaryServiceToken,omitempty"`
 }
 
 //CreateL2ConnectionResponse post l2 connection response

--- a/rest_l2_connection.go
+++ b/rest_l2_connection.go
@@ -224,6 +224,7 @@ func createL2RedundantConnectionRequest(primary L2Connection, secondary L2Connec
 	connReq.SecondarySellerMetroCode = secondary.SellerMetroCode
 	connReq.SecondarySellerRegion = secondary.SellerRegion
 	connReq.SecondaryInterfaceID = secondary.DeviceInterfaceID
+	connReq.SecondaryServiceToken = secondary.ServiceToken
 	return connReq
 }
 

--- a/rest_l2_connection_test.go
+++ b/rest_l2_connection_test.go
@@ -216,6 +216,7 @@ func TestCreateRedundantL2Connection(t *testing.T) {
 		Name:              String("secName"),
 		PortUUID:          String("secondaryPortUUID"),
 		DeviceUUID:        String("secondaryDeviceUUID"),
+		ServiceToken:      String("secondaryServiceToken"),
 		VlanSTag:          Int(690),
 		VlanCTag:          Int(691),
 		ZSidePortUUID:     String("secondaryZSidePortUUID"),


### PR DESCRIPTION
`secondaryServiceToken` is required for redundant connection, since for now a service token can only be issued for a single port - connection pair, and unlike directly specifying an Equinix port, with service token it is not possible to reuse same one for both primary and secondary.