### PR TITLE
support for feature l2connection PrimaryZSideServiceToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 2.3.0 (July 15, 2022)
+
+DEPRECATION:
+
+* General change in GET L2 connections functions: *ServiceToken* should not be used to populate the
+a-side token with which the connection was created. It is maintained for historical compability but
+can contain both a-side/z-side tokens. To access the token returned by a GET operation use the
+L2Connection.VendorToken string. Change affects below functions:
+  * `GetL2Connection`
+  * `GetL2OutgoingConnections`
+
+ENHANCEMENTS:
+
+* **L2Connection** added additional attributes:
+  * *ZSideServiceToken* can be used (in addition to service profile and zside port) to define the
+  connection destination. key given by a provider that grants you authorization to enable
+  connectivity to a shared multi-tenant port (z-side)
+  * *VendorToken* can be used to populate the Equinix Fabric Token the connection was created with
+  (if applicable).The token can be any of *ServiceToken* (a-side) or *ZSideServiceToken* (z-side).
+  Any mechanism to determine the token type (a-side/z-side), must be implemented by the
+  user/consumer of the SDK.
+
 ## 2.2.0 (March 11, 2022)
 
 FEATURES:

--- a/client.go
+++ b/client.go
@@ -102,6 +102,7 @@ type L2Connection struct {
 	Actions             []L2ConnectionAction
 	ServiceToken        *string
 	ZSideServiceToken   *string
+	VendorToken         *string
 }
 
 //L2ConnectionAdditionalInfo additional info object used in L2 connections

--- a/client.go
+++ b/client.go
@@ -100,8 +100,23 @@ type L2Connection struct {
 	RedundancyType      *string
 	RedundancyGroup     *string
 	Actions             []L2ConnectionAction
+	// ServiceToken is used to create connections with an a-side Equinix Fabric Token
+	// Applicable for CREATE operations: CreateL2Connection, CreateL2RedundantConnection...
+	//
+	// Deprecated: ServiceToken (GET operations) - Starting with v2.3.0 this field should not be
+	// used to populate the a-side token with which the connection was created. It is maintained
+	// for historical compability but can contain both a-side/z-side tokens. To access the token
+	// returned by a GET operation (GetL2Connection, GetL2OutgoingConnections...), use the
+	// L2Connection.VendorToken string.
 	ServiceToken        *string
+	// ZSideServiceToken is used to create connections using a z-side Equinix Fabric Token
+	// Applicable for CREATE operations: CreateL2Connection, CreateL2RedundantConnection...
 	ZSideServiceToken   *string
+	// VendorToken is used in GET Operations (GetL2Connection, GetL2OutgoingConnections...) to
+	// populate the Equinix Fabric Token the connection was created with (if applicable). The token
+	// can be any of ServiceToken (a-side) or ZSideServiceToken (z-side). Any mechanism to
+	// determine the token type (a-side/z-side), must be implemented by the user/consumer of the
+	// SDK.
 	VendorToken         *string
 }
 

--- a/client.go
+++ b/client.go
@@ -101,6 +101,7 @@ type L2Connection struct {
 	RedundancyGroup     *string
 	Actions             []L2ConnectionAction
 	ServiceToken        *string
+	ZSideServiceToken   *string
 }
 
 //L2ConnectionAdditionalInfo additional info object used in L2 connections

--- a/internal/api/l2_connection.go
+++ b/internal/api/l2_connection.go
@@ -46,13 +46,14 @@ type L2ConnectionRequest struct {
 	PurchaseOrderNumber        *string                      `json:"purchaseOrderNumber"`
 	PrimaryPortUUID            *string                      `json:"primaryPortUUID,omitempty"`
 	VirtualDeviceUUID          *string                      `json:"virtualDeviceUUID,omitempty"`
-	PrimaryServiceToken        *string                      `json:"primaryServiceToken,omitempty"`
 	InterfaceID                *int                         `json:"interfaceId,omitempty"`
 	PrimaryVlanSTag            *int                         `json:"primaryVlanSTag,omitempty"`
 	PrimaryVlanCTag            *int                         `json:"primaryVlanCTag,omitempty"`
 	NamedTag                   *string                      `json:"namedTag,omitempty"`
 	AdditionalInfo             []L2ConnectionAdditionalInfo `json:"additionalInfo,omitempty"`
+	PrimaryServiceToken        *string                      `json:"primaryServiceToken,omitempty"`
 	PrimaryZSidePortUUID       *string                      `json:"primaryZSidePortUUID,omitempty"`
+	PrimaryZSideServiceToken   *string                      `json:"primaryZSideServiceToken,omitempty"`
 	PrimaryZSideVlanSTag       *int                         `json:"primaryZSideVlanSTag,omitempty"`
 	PrimaryZSideVlanCTag       *int                         `json:"primaryZSideVlanCTag,omitempty"`
 	SecondaryName              *string                      `json:"secondaryName,omitempty"`

--- a/rest_l2_connection.go
+++ b/rest_l2_connection.go
@@ -150,6 +150,18 @@ func (req *restL2ConnectionUpdateRequest) Execute() error {
 }
 
 func mapGETToL2Connection(getResponse api.L2ConnectionResponse) *L2Connection {
+	//Both a-side/z-side service tokens are returned in the vendorToken attribute.
+	//Service tokens cannot be used for both sides in a single connection.
+	//To distinguish between the two options, any service profile (SP) field can give us a hint,
+	//since service tokens are created at port level and not through an SP, and SPs are always
+	//the z-side of the connection, so in that case service token can only be used for the a-side.
+	var serviceToken, zSideServiceToken *string
+	if getResponse.SellerServiceUUID != nil || getResponse.AuthorizationKey != nil {
+		serviceToken = getResponse.VendorToken
+	} else {
+		zSideServiceToken = getResponse.VendorToken
+	}
+
 	return &L2Connection{
 		UUID:                getResponse.UUID,
 		Name:                getResponse.Name,
@@ -176,32 +188,34 @@ func mapGETToL2Connection(getResponse api.L2ConnectionResponse) *L2Connection {
 		RedundancyType:      getResponse.RedundancyType,
 		RedundancyGroup:     getResponse.RedundancyGroup,
 		Actions:             mapL2ConnectionActionsAPIToDomain(getResponse.ActionDetails),
-		ServiceToken:        getResponse.VendorToken,
+		ServiceToken:        serviceToken,
+		ZSideServiceToken:   zSideServiceToken,
 	}
 }
 
 func createL2ConnectionRequest(l2connection L2Connection) api.L2ConnectionRequest {
 	return api.L2ConnectionRequest{
-		PrimaryName:          l2connection.Name,
-		ProfileUUID:          l2connection.ProfileUUID,
-		Speed:                l2connection.Speed,
-		SpeedUnit:            l2connection.SpeedUnit,
-		Notifications:        l2connection.Notifications,
-		PurchaseOrderNumber:  l2connection.PurchaseOrderNumber,
-		PrimaryPortUUID:      l2connection.PortUUID,
-		VirtualDeviceUUID:    l2connection.DeviceUUID,
-		InterfaceID:          l2connection.DeviceInterfaceID,
-		PrimaryVlanSTag:      l2connection.VlanSTag,
-		PrimaryVlanCTag:      l2connection.VlanCTag,
-		NamedTag:             l2connection.NamedTag,
-		AdditionalInfo:       mapAdditionalInfoDomainToAPI(l2connection.AdditionalInfo),
-		PrimaryZSidePortUUID: l2connection.ZSidePortUUID,
-		PrimaryZSideVlanSTag: l2connection.ZSideVlanSTag,
-		PrimaryZSideVlanCTag: l2connection.ZSideVlanCTag,
-		SellerRegion:         l2connection.SellerRegion,
-		SellerMetroCode:      l2connection.SellerMetroCode,
-		AuthorizationKey:     l2connection.AuthorizationKey,
-		PrimaryServiceToken:  l2connection.ServiceToken,
+		PrimaryName:              l2connection.Name,
+		ProfileUUID:              l2connection.ProfileUUID,
+		Speed:                    l2connection.Speed,
+		SpeedUnit:                l2connection.SpeedUnit,
+		Notifications:            l2connection.Notifications,
+		PurchaseOrderNumber:      l2connection.PurchaseOrderNumber,
+		PrimaryPortUUID:          l2connection.PortUUID,
+		VirtualDeviceUUID:        l2connection.DeviceUUID,
+		InterfaceID:              l2connection.DeviceInterfaceID,
+		PrimaryVlanSTag:          l2connection.VlanSTag,
+		PrimaryVlanCTag:          l2connection.VlanCTag,
+		NamedTag:                 l2connection.NamedTag,
+		AdditionalInfo:           mapAdditionalInfoDomainToAPI(l2connection.AdditionalInfo),
+		PrimaryZSidePortUUID:     l2connection.ZSidePortUUID,
+		PrimaryZSideVlanSTag:     l2connection.ZSideVlanSTag,
+		PrimaryZSideVlanCTag:     l2connection.ZSideVlanCTag,
+		SellerRegion:             l2connection.SellerRegion,
+		SellerMetroCode:          l2connection.SellerMetroCode,
+		AuthorizationKey:         l2connection.AuthorizationKey,
+		PrimaryServiceToken:      l2connection.ServiceToken,
+		PrimaryZSideServiceToken: l2connection.ZSideServiceToken,
 	}
 }
 

--- a/rest_l2_connection.go
+++ b/rest_l2_connection.go
@@ -150,18 +150,6 @@ func (req *restL2ConnectionUpdateRequest) Execute() error {
 }
 
 func mapGETToL2Connection(getResponse api.L2ConnectionResponse) *L2Connection {
-	//Both a-side/z-side service tokens are returned in the vendorToken attribute.
-	//Service tokens cannot be used for both sides in a single connection.
-	//To distinguish between the two options, any service profile (SP) field can give us a hint,
-	//since service tokens are created at port level and not through an SP, and SPs are always
-	//the z-side of the connection, so in that case service token can only be used for the a-side.
-	var serviceToken, zSideServiceToken *string
-	if getResponse.SellerServiceUUID != nil || getResponse.AuthorizationKey != nil {
-		serviceToken = getResponse.VendorToken
-	} else {
-		zSideServiceToken = getResponse.VendorToken
-	}
-
 	return &L2Connection{
 		UUID:                getResponse.UUID,
 		Name:                getResponse.Name,
@@ -188,8 +176,7 @@ func mapGETToL2Connection(getResponse api.L2ConnectionResponse) *L2Connection {
 		RedundancyType:      getResponse.RedundancyType,
 		RedundancyGroup:     getResponse.RedundancyGroup,
 		Actions:             mapL2ConnectionActionsAPIToDomain(getResponse.ActionDetails),
-		ServiceToken:        serviceToken,
-		ZSideServiceToken:   zSideServiceToken,
+		VendorToken:         getResponse.VendorToken,
 	}
 }
 

--- a/rest_l2_connection.go
+++ b/rest_l2_connection.go
@@ -176,6 +176,7 @@ func mapGETToL2Connection(getResponse api.L2ConnectionResponse) *L2Connection {
 		RedundancyType:      getResponse.RedundancyType,
 		RedundancyGroup:     getResponse.RedundancyGroup,
 		Actions:             mapL2ConnectionActionsAPIToDomain(getResponse.ActionDetails),
+		ServiceToken:        getResponse.VendorToken,
 		VendorToken:         getResponse.VendorToken,
 	}
 }

--- a/rest_l2_connection_test.go
+++ b/rest_l2_connection_test.go
@@ -31,7 +31,10 @@ var testPrimaryConnection = L2Connection{
 	ZSideVlanCTag:       Int(201),
 	SellerRegion:        String("EMEA"),
 	SellerMetroCode:     String("AM"),
-	AuthorizationKey:    String("authorizationKey")}
+	AuthorizationKey:    String("authorizationKey"),
+	ServiceToken:        String("serviceToken"),
+	ZSideServiceToken:   String("zsideServiceToken"),
+}
 
 func TestGetL2OutgoingConnections(t *testing.T) {
 	//Given
@@ -147,72 +150,6 @@ func TestCreateDeviceL2Connection(t *testing.T) {
 	newConnection := testPrimaryConnection
 	newConnection.DeviceUUID = String("deviceUUID")
 	newConnection.DeviceInterfaceID = Int(5)
-
-	//When
-	ecxClient := NewClient(context.Background(), baseURL, testHc)
-	uuid, err := ecxClient.CreateL2Connection(newConnection)
-
-	//Then
-	assert.Nil(t, err, "Client should not return an error")
-	assert.NotNil(t, uuid, "Client should return a response")
-	verifyL2ConnectionRequest(t, newConnection, reqBody)
-	assert.Equal(t, uuid, respBody.PrimaryConnectionID, "UUID matches")
-}
-
-func TestCreateServiceTokenAsideL2Connection(t *testing.T) {
-	//Given
-	respBody := api.CreateL2ConnectionResponse{}
-	if err := readJSONData("./test-fixtures/ecx_l2connection_post_resp.json", &respBody); err != nil {
-		assert.Failf(t, "Cannot read test response due to %s", err.Error())
-	}
-	reqBody := api.L2ConnectionRequest{}
-	testHc := &http.Client{}
-	httpmock.ActivateNonDefault(testHc)
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/ecx/v3/l2/connections", baseURL),
-		func(r *http.Request) (*http.Response, error) {
-			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
-				return httpmock.NewStringResponse(400, ""), nil
-			}
-			resp, _ := httpmock.NewJsonResponse(200, respBody)
-			return resp, nil
-		},
-	)
-	defer httpmock.DeactivateAndReset()
-	newConnection := testPrimaryConnection
-	newConnection.ServiceToken = String("serviceToken")
-
-	//When
-	ecxClient := NewClient(context.Background(), baseURL, testHc)
-	uuid, err := ecxClient.CreateL2Connection(newConnection)
-
-	//Then
-	assert.Nil(t, err, "Client should not return an error")
-	assert.NotNil(t, uuid, "Client should return a response")
-	verifyL2ConnectionRequest(t, newConnection, reqBody)
-	assert.Equal(t, uuid, respBody.PrimaryConnectionID, "UUID matches")
-}
-
-func TestCreateServiceZsideTokenL2Connection(t *testing.T) {
-	//Given
-	respBody := api.CreateL2ConnectionResponse{}
-	if err := readJSONData("./test-fixtures/ecx_l2connection_post_resp.json", &respBody); err != nil {
-		assert.Failf(t, "Cannot read test response due to %s", err.Error())
-	}
-	reqBody := api.L2ConnectionRequest{}
-	testHc := &http.Client{}
-	httpmock.ActivateNonDefault(testHc)
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/ecx/v3/l2/connections", baseURL),
-		func(r *http.Request) (*http.Response, error) {
-			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
-				return httpmock.NewStringResponse(400, ""), nil
-			}
-			resp, _ := httpmock.NewJsonResponse(200, respBody)
-			return resp, nil
-		},
-	)
-	defer httpmock.DeactivateAndReset()
-	newConnection := testPrimaryConnection
-	newConnection.ZSideServiceToken = String("serviceToken")
 
 	//When
 	ecxClient := NewClient(context.Background(), baseURL, testHc)

--- a/rest_l2_connection_test.go
+++ b/rest_l2_connection_test.go
@@ -159,7 +159,7 @@ func TestCreateDeviceL2Connection(t *testing.T) {
 	assert.Equal(t, uuid, respBody.PrimaryConnectionID, "UUID matches")
 }
 
-func TestCreateServiceTokenL2Connection(t *testing.T) {
+func TestCreateServiceTokenAsideL2Connection(t *testing.T) {
 	//Given
 	respBody := api.CreateL2ConnectionResponse{}
 	if err := readJSONData("./test-fixtures/ecx_l2connection_post_resp.json", &respBody); err != nil {
@@ -180,6 +180,39 @@ func TestCreateServiceTokenL2Connection(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	newConnection := testPrimaryConnection
 	newConnection.ServiceToken = String("serviceToken")
+
+	//When
+	ecxClient := NewClient(context.Background(), baseURL, testHc)
+	uuid, err := ecxClient.CreateL2Connection(newConnection)
+
+	//Then
+	assert.Nil(t, err, "Client should not return an error")
+	assert.NotNil(t, uuid, "Client should return a response")
+	verifyL2ConnectionRequest(t, newConnection, reqBody)
+	assert.Equal(t, uuid, respBody.PrimaryConnectionID, "UUID matches")
+}
+
+func TestCreateServiceZsideTokenL2Connection(t *testing.T) {
+	//Given
+	respBody := api.CreateL2ConnectionResponse{}
+	if err := readJSONData("./test-fixtures/ecx_l2connection_post_resp.json", &respBody); err != nil {
+		assert.Failf(t, "Cannot read test response due to %s", err.Error())
+	}
+	reqBody := api.L2ConnectionRequest{}
+	testHc := &http.Client{}
+	httpmock.ActivateNonDefault(testHc)
+	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/ecx/v3/l2/connections", baseURL),
+		func(r *http.Request) (*http.Response, error) {
+			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+				return httpmock.NewStringResponse(400, ""), nil
+			}
+			resp, _ := httpmock.NewJsonResponse(200, respBody)
+			return resp, nil
+		},
+	)
+	defer httpmock.DeactivateAndReset()
+	newConnection := testPrimaryConnection
+	newConnection.ZSideServiceToken = String("serviceToken")
 
 	//When
 	ecxClient := NewClient(context.Background(), baseURL, testHc)
@@ -359,6 +392,7 @@ func verifyL2ConnectionRequest(t *testing.T, conn L2Connection, req api.L2Connec
 	assert.Equal(t, conn.SellerMetroCode, req.SellerMetroCode, "SellerMetroCode matches")
 	assert.Equal(t, conn.AuthorizationKey, req.AuthorizationKey, "AuthorizationKey matches")
 	assert.Equal(t, conn.ServiceToken, req.PrimaryServiceToken, "PrimaryServiceToken matches")
+	assert.Equal(t, conn.ZSideServiceToken, req.PrimaryZSideServiceToken, "PrimaryZSideServiceToken matches")
 
 	assert.Equal(t, len(conn.AdditionalInfo), len(req.AdditionalInfo), "AdditionalInfo array size matches")
 	for i := range conn.AdditionalInfo {


### PR DESCRIPTION
Feature required to support z-side service token.

As described in [code](https://github.com/equinix/ecx-go/compare/zside_service_token_feature?expand=1#diff-1b478265018d763b8373cc073c611f41bf29f87718e1044285ea897d97f6b510R153-R157) both a-side/z-side are returned in `vendorToken` attribute.  A little logic has been implemented to distinguish a-side/z-side tokens.