### PR TITLE
include 2nd device in API call even when both are same one

### DIFF
--- a/rest_l2_connection.go
+++ b/rest_l2_connection.go
@@ -211,9 +211,7 @@ func createL2RedundantConnectionRequest(primary L2Connection, secondary L2Connec
 	connReq := createL2ConnectionRequest(primary)
 	connReq.SecondaryName = secondary.Name
 	connReq.SecondaryPortUUID = secondary.PortUUID
-	if StringValue(primary.DeviceUUID) != StringValue(secondary.DeviceUUID) {
-		connReq.SecondaryVirtualDeviceUUID = secondary.DeviceUUID
-	}
+	connReq.SecondaryVirtualDeviceUUID = secondary.DeviceUUID
 	connReq.SecondaryVlanSTag = secondary.VlanSTag
 	connReq.SecondaryVlanCTag = secondary.VlanCTag
 	connReq.SecondaryZSidePortUUID = secondary.ZSidePortUUID

--- a/rest_l2_connection_test.go
+++ b/rest_l2_connection_test.go
@@ -396,7 +396,7 @@ func TestCreateL2RedundantConnectionRequest_oneDevice(t *testing.T) {
 	//when
 	request := createL2RedundantConnectionRequest(primary, secondary)
 	//then
-	assert.Nil(t, request.SecondaryVirtualDeviceUUID, "Secondary device UUID is not set")
+	assert.Equal(t, secondary.DeviceUUID, request.SecondaryVirtualDeviceUUID, "Secondary deviceUUID matches")
 	assert.Equal(t, secondary.Name, request.SecondaryName, "Secondary name matches")
 	assert.Equal(t, secondary.DeviceInterfaceID, request.SecondaryInterfaceID, "Secondary deviceInterfaceID name matches")
 }


### PR DESCRIPTION
This fixes issue reported in terraform provider https://github.com/equinix/terraform-provider-equinix/issues/347

It doesn't create the secondary connection if you are using same device as the primary connection. That used to work, but it seems that a recent change to the billing process (it is now possible to create a single connection to Azure, without an SLA provided by Azure) is causing this to fail. There's no reason/use case from the API perspective not to include the second device id
